### PR TITLE
Update dovecot.grok

### DIFF
--- a/patterns.d/dovecot.grok
+++ b/patterns.d/dovecot.grok
@@ -6,6 +6,7 @@ DOVECOT_RIP rip=%{IP:dovecot_remote_ip}
 DOVECOT_METHOD method=%{WORD:dovecot_method}
 DOVECOT_MPID mpid=%{NUMBER:dovecot_mpid}
 DOVECOT_USER user=<%{DATA:dovecot_user}>
+DOVECOT_SESSION session=<%{DATA:dovecot_session}>
 
 DOVECOT_BYTES bytes=%{NUMBER:dovecot_bytes_in}/%{NUMBER:dovecot_bytes_out}
 DOVECOT_TOP top=%{NUMBER:dovecot_cmd_top}/%{NUMBER:dovecot_bytes_top}
@@ -15,7 +16,7 @@ DOVECOT_SIZE size=%{NUMBER:dovecot_size}
 
 DOVECOT_SSL_SECURITY ssl_security="%{NOTSPACE:dovecot_ssl_proto} with cipher %{DATA:dovecot_ssl_cipher}"
 
-DOVECOT_ELEMENT %{DOVECOT_LIP}|%{DOVECOT_RIP}|%{DOVECOT_METHOD}|%{DOVECOT_MPID}|%{DOVECOT_USER}|%{DOVECOT_BYTES}|%{DOVECOT_TOP}|%{DOVECOT_RETR}|%{DOVECOT_DEL}|%{DOVECOT_SIZE}
+DOVECOT_ELEMENT %{DOVECOT_LIP}|%{DOVECOT_RIP}|%{DOVECOT_METHOD}|%{DOVECOT_MPID}|%{DOVECOT_USER}|%{DOVECOT_SESSION}|%{DOVECOT_BYTES}|%{DOVECOT_TOP}|%{DOVECOT_RETR}|%{DOVECOT_DEL}|%{DOVECOT_SIZE}
 DOVECOT_ELEMENTS %{DOVECOT_ELEMENT}(, %{DOVECOT_ELEMENT})*
 
 DOVECOT_MESSAGE (%{WORD:dovecot_auth_backend}\(%{DATA:dovecot_user},%{IP:dovecot_remote_ip}\): )?%{DATA:dovecot_message}


### PR DESCRIPTION
This pattern doesn't know about "session=<sessionID>". Because of the "$" in "DOVECOT" that ended up making the "DOVECOT_USER" pattern greedy and scan all the way to the end of the session ID, skipping over all intermediate DOVECOT_ELEMENTS. This patch fixes that.